### PR TITLE
:arrow_up: Bump the bundler group across 1 directory with 2 updates

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -138,6 +138,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.5-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.5-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)


### PR DESCRIPTION
Bumps the bundler group with 2 updates in the /api directory: [nokogiri](https://github.com/sparklemotion/nokogiri) and [rexml](https://github.com/ruby/rexml).

Updates `nokogiri` from 1.16.3 to 1.16.5
- [Release notes](https://github.com/sparklemotion/nokogiri/releases)
- [Changelog](https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md)
- [Commits](https://github.com/sparklemotion/nokogiri/compare/v1.16.3...v1.16.5)

Updates `rexml` from 3.2.6 to 3.2.8
- [Release notes](https://github.com/ruby/rexml/releases)
- [Changelog](https://github.com/ruby/rexml/blob/master/NEWS.md)
- [Commits](https://github.com/ruby/rexml/compare/v3.2.6...v3.2.8)

---
updated-dependencies:
- dependency-name: nokogiri dependency-type: indirect dependency-group: bundler
- dependency-name: rexml dependency-type: indirect dependency-group: bundler ...

Signed-off-by: dependabot[bot] <support@github.com>

fixup